### PR TITLE
Add jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ You must manually include these if you choose to use the script installation:_
 
 ```html
 <script src="https://unpkg.com/hawk/lib/browser.js"></script>
+<!-- or from the jsDelivr CDN -->
 <script src="https://cdn.jsdelivr.net/npm/hawk/dist/browser.js"></script>
 <script>
 // hawk's "browser" client doesn't expose itself on window
 window.hawk = hawk;
 </script>
 <script src="https://wzrd.in/standalone/query-string"></script>
+
 <script src="https://unpkg.com/taskcluster-client-web"></script>
+<!-- or from the jsDelivr CDN -->
 <script src="https://cdn.jsdelivr.net/npm/taskcluster-client-web/lib/index.js"></script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ npm install --save taskcluster-client-web
 
 <!-- You can also include it from the unpkg CDN -->
 <script src="https://unpkg.com/taskcluster-client-web"></script>
+
+<!-- or from the jsDelivr CDN -->
+<script src="https://cdn.jsdelivr.net/npm/taskcluster-client-web/lib/index.js"></script>
 ```
 
 _Note: taskcluster-client-web depends on 2 external packages: hawk and query-string.
@@ -36,12 +39,14 @@ You must manually include these if you choose to use the script installation:_
 
 ```html
 <script src="https://unpkg.com/hawk/lib/browser.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/hawk/dist/browser.js"></script>
 <script>
 // hawk's "browser" client doesn't expose itself on window
 window.hawk = hawk;
 </script>
 <script src="https://wzrd.in/standalone/query-string"></script>
 <script src="https://unpkg.com/taskcluster-client-web"></script>
+<script src="https://cdn.jsdelivr.net/npm/taskcluster-client-web/lib/index.js"></script>
 ```
 
 ## Usage


### PR DESCRIPTION
[jsDelivr](https://www.jsdelivr.com/) is the [fastest opensource cdn](https://www.cdnperf.com/) available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg. This PR adds it to the readme as an alternative to unpkg.