### PR TITLE
Remove Content-Type headers for requests with no body

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -30,7 +30,7 @@ const handleResponse = response => Promise
   });
 
 export default (url, opts = {}) => {
-  const options = { ...defaults, ...opts, headers: { ...defaults.headers, ...opts.headers } };
+  const options = { ...defaults, ...opts, headers: { ...(opts.body && defaults.headers), ...opts.headers } };
   const { delayFactor, randomizationFactor, maxDelay, retries } = options;
 
   if (typeof options.credentials !== 'string') {


### PR DESCRIPTION
This appears to be what was causing the fetches of `actions.json` to fail. S3 was yelling at us since we were setting `Content-Type` on requests with no body.