### PR TITLE
Lock OIDCCredentialAgent getCredentials behind cross-tab mutex

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "object.omit": "^3.0.0"
   },
   "dependencies": {
+    "fast-mutex": "^1.0.2",
     "hawk": "^6.0.2",
     "query-string": "^5.0.0"
   }

--- a/src/agents/OIDCCredentialAgent.js
+++ b/src/agents/OIDCCredentialAgent.js
@@ -1,7 +1,7 @@
 import Mutex from 'fast-mutex';
 import fetch from '../fetch';
 
-const MUTEX_LOCK_KEY = '@@TASKCLUSTER_SESSION';
+const MUTEX_LOCK_KEY = '@@TASKCLUSTER_CLIENT_WEB_CREDENTIALS';
 
 /**
  * A credential agent that fetches the credentials from the taskcluster
@@ -27,6 +27,8 @@ export default class OIDCCredentialAgent {
   }
 
   async getCredentials() {
+    // If we already have a credentials promise, check to see if they have expired.
+    // If not, we can just return the credentials we have cached in the promise.
     if (this.credentialsPromise && this.credentialsExpire > new Date()) {
       return this.credentialsPromise;
     }
@@ -36,24 +38,32 @@ export default class OIDCCredentialAgent {
     const url = `${loginBaseUrl}/v1/oidc-credentials/${this.oidcProvider}`;
     const mutex = new Mutex();
 
+    // Lock access to this value across tabs so only 1 leader instance does
+    // a fetch for credentials. This await will resolve for the leader first
+    // so it can set the session value. The peers will resolve once the leader
+    // unlocks the mutex, and can access the session set by the leader. This
+    // mutex will unlock in 5 seconds if it has not been resolved by the leader
+    // in that time.
     await mutex.lock(MUTEX_LOCK_KEY);
 
+    // The existence of the session in localStorage drives whether we are the
+    // mutex leader or just a peer. The leader, being unlocked first, will have
+    // an empty session, and is therefore responsible for setting the session.
+    // The peers will unlock once the leader has released its lock, and can
+    // access this session value.
     const session = localStorage.getItem(MUTEX_LOCK_KEY);
 
-    // If the session exists, it was set by the leader mutex. Grab the
-    // credentials from storage and pass them on.
     if (session) {
+      // If the session exists, it was set by the leader mutex. Grab the
+      // credentials from storage and pass them on.
       const response = JSON.parse(session);
 
       this.credentialsExpire = new Date(response.expires);
       this.credentialsPromise = Promise.resolve(response.credentials);
+      await mutex.release(MUTEX_LOCK_KEY);
     } else {
       // With nothing in localStorage, we are the leader mutex, and will
-      // be logging in for all other sessions. Make the request, set the
-      // value in storage, then unlock the mutex for peers.
-      // We will also blow away the session from storage in 30 seconds
-      // as a recovery mechanism, and to also ensure that the next login
-      // gets a clean slate.
+      // be logging in for all other sessions. Fetch the remote credentials.
       this.credentialsPromise = new Promise(async (resolve, reject) => {
         try {
           const response = await fetch(url, {
@@ -63,21 +73,42 @@ export default class OIDCCredentialAgent {
           });
 
           this.credentialsExpire = new Date(response.expires);
+
+          // Since we are the mutex leader, it's our job to set the value in
+          // localStorage for the peers to access.
           localStorage.setItem(MUTEX_LOCK_KEY, JSON.stringify(response));
 
           setTimeout(() => {
+            // We remove the session from storage in 30 seconds as it is not
+            // the responsibility of this library to perform persistence. Rather,
+            // localStorage is merely the means of enabling cross-tab communication
+            // and we want to leave the session in the same state we found it. It
+            // is still up to the agent consumer to persist these credentials
+            // however they decide. We also want to ensure that whenever the current
+            // credentials have expired that we don't run into a situation where we
+            // resolve with stale credentials, so we let the credentialsPromise and
+            // credentialsExpire drive this and avoid localStorage somehow interfering.
             localStorage.removeItem(MUTEX_LOCK_KEY);
           }, 30000);
 
+          // We are done fetching the credentials and setting the value for peers to
+          // access. Release our lock and let them pull the value from storage.
           await mutex.release(MUTEX_LOCK_KEY);
+
+          // As the leader we still need to give the caller access to the credentials.
           resolve(response.credentials);
         } catch (err) {
+          // Something went wrong with the request, so our promise is not valid.
+          // We still need to unblock our peers to make their own requests as a
+          // backup.
           this.credentialsPromise = null;
+          await mutex.release(MUTEX_LOCK_KEY);
           reject(err);
         }
       });
     }
 
+    // We return this promise so credentials access is cached until expiration.
     return this.credentialsPromise;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2709,6 +2709,12 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-mutex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fast-mutex/-/fast-mutex-1.0.2.tgz#29a00d621f3b5af1f244c2762bdef7681c000a45"
+  dependencies:
+    debug "^2.2.0"
+
 fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"


### PR DESCRIPTION
See comments for description about how this works. Using `fast-mutex` syncs a mutex across tabs via localStorage.

Using this would supersede the work in tools by building this directly into the credential agent, so I think everyone benefits, especially the login service. 😃 

I'm still unsure about feasibility, so happy to open a dialogue.